### PR TITLE
move bluetooth device name to build_flags

### DIFF
--- a/code/ESP32/SkyeTracker/platformio.ini
+++ b/code/ESP32/SkyeTracker/platformio.ini
@@ -47,6 +47,8 @@ build_flags =
     -D AnemometerWindSpeedProtection=28.8
     ; MQTT
     -D MQTT_MAX_PACKET_SIZE=1024
+    ; Bluetooth
+    '-DBluetoothDeviceName="HC-06"'
     ; WIFI
     -D AP_TIMEOUT=30000
     -D APP_LOG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG

--- a/code/ESP32/SkyeTracker/src/main.cpp
+++ b/code/ESP32/SkyeTracker/src/main.cpp
@@ -140,7 +140,7 @@ void setup()
 	_config.Load();
 	_iot.Init();
 	_lastWindEvent = 0;
-	ESP_BT.begin("HC-06"); // backward compatible with Android app
+	ESP_BT.begin(BluetoothDeviceName);
 	while (!ESP_BT.isReady())
 	{
 		;


### PR DESCRIPTION
move BT device name to build_flags when using multiple SkyeTracker devices.